### PR TITLE
Fix verigreen Dockerfile to use $APP_DIR instead of $VG_ROOT as WORKDIR

### DIFF
--- a/verigreen/Dockerfile
+++ b/verigreen/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 										&& \
 										apt-get clean
 
-WORKDIR $VG_ROOT
+WORKDIR $APP_DIR
 
 ADD pre-entrypoint.sh pre-entrypoint.sh
 ADD update_hosts.sh update_hosts.sh


### PR DESCRIPTION
$VG_ROOT was replaced with $APP_DIR in the new version of verigreen docker image